### PR TITLE
Add Gradle build files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'java'
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+    implementation 'org.apache.commons:commons-math3:3.6.1'
+    implementation 'org.slf4j:slf4j-api:2.0.7'
+    runtimeOnly 'org.slf4j:slf4j-simple:2.0.7'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'FMCv2'


### PR DESCRIPTION
## Summary
- add `build.gradle` to configure Java plugin with Java 17 toolchain
- add dependencies for JUnit, Commons Math, and SLF4J logging
- create `settings.gradle` naming the root project

## Testing
- `gradle test --no-daemon` *(fails: cannot locate Java 17 toolchain)*