### PR TITLE
Add fluid-dynamics engine and uniformity optimiser

### DIFF
--- a/src/main/java/org/example/flowmod/engine/DefaultDrillSizePolicy.java
+++ b/src/main/java/org/example/flowmod/engine/DefaultDrillSizePolicy.java
@@ -9,6 +9,6 @@ public class DefaultDrillSizePolicy implements DrillSizePolicy {
         if (spec == null) {
             throw new IllegalArgumentException("spec must not be null");
         }
-        return spec.diameter();
+        return spec.holeDiameterMm();
     }
 }

--- a/src/main/java/org/example/flowmod/engine/DrillUtils.java
+++ b/src/main/java/org/example/flowmod/engine/DrillUtils.java
@@ -7,7 +7,72 @@ public final class DrillUtils {
     private DrillUtils() {
     }
 
-    public static HoleSpec createHole(double diameter, double position) {
-        return new HoleSpec(diameter, position);
+    public static HoleSpec createHole(int rowIndex, double diameterMm, double angleDeg) {
+        return new HoleSpec(rowIndex, diameterMm, angleDeg);
+    }
+
+    /**
+     * Largest-first taper algorithm.
+     */
+    public static HoleLayout taperWithRules(
+            HoleLayout blank, java.util.List<Double> drillSet, FlowParameters p) {
+        java.util.List<HoleSpec> holes = new java.util.ArrayList<>(blank.getHoles());
+        if (holes.isEmpty()) {
+            return blank;
+        }
+        drillSet = new java.util.ArrayList<>(drillSet);
+        drillSet.sort(java.util.Comparator.reverseOrder());
+
+        // assign largest drill to all rows
+        double largest = drillSet.get(0);
+        for (int i = 0; i < holes.size(); i++) {
+            HoleSpec h = holes.get(i);
+            holes.set(i, new HoleSpec(h.rowIndex(), largest, h.angleDeg()));
+        }
+
+        HoleLayout layout = toLayout(holes);
+        double error = FlowPhysics.computeUniformityError(layout, p);
+        int drillIdxMax = drillSet.size() - 1;
+
+        // target 5% coefficient of variation
+        final double target = 5.0;
+        while (error > target) {
+            boolean changed = false;
+            for (int i = 0; i < holes.size() && error > target; i++) {
+                HoleSpec h = holes.get(i);
+                int pos = drillSet.indexOf(h.holeDiameterMm());
+                if (pos < drillIdxMax) {
+                    holes.set(i, new HoleSpec(h.rowIndex(), drillSet.get(pos + 1), h.angleDeg()));
+                    layout = toLayout(holes);
+                    error = FlowPhysics.computeUniformityError(layout, p);
+                    changed = true;
+                }
+            }
+            if (!changed) {
+                break;
+            }
+        }
+
+        return minimiseDrillChanges(layout);
+    }
+
+    private static HoleLayout minimiseDrillChanges(HoleLayout layout) {
+        java.util.List<HoleSpec> result = new java.util.ArrayList<>();
+        HoleSpec prev = null;
+        for (HoleSpec h : layout.getHoles()) {
+            if (prev == null || Double.compare(prev.holeDiameterMm(), h.holeDiameterMm()) != 0) {
+                result.add(h);
+                prev = h;
+            }
+        }
+        return toLayout(result);
+    }
+
+    private static HoleLayout toLayout(java.util.List<HoleSpec> specs) {
+        HoleLayout layout = new HoleLayout();
+        for (HoleSpec h : specs) {
+            layout.addHole(h);
+        }
+        return layout;
     }
 }

--- a/src/main/java/org/example/flowmod/engine/FlowParameters.java
+++ b/src/main/java/org/example/flowmod/engine/FlowParameters.java
@@ -2,5 +2,10 @@ package org.example.flowmod.engine;
 
 /**
  * Parameters describing the fluid flow system.
+ *
+ * @param pipeDiameterMm internal pipe diameter in millimetres
+ * @param flowLps        total volumetric flow supplied to the header in litres per second
+ * @param headerLenMm    header length in millimetres
  */
-public record FlowParameters(double flowRate, double pressure) {}
+public record FlowParameters(double pipeDiameterMm, double flowLps, double headerLenMm) {
+}

--- a/src/main/java/org/example/flowmod/engine/FlowPhysics.java
+++ b/src/main/java/org/example/flowmod/engine/FlowPhysics.java
@@ -1,14 +1,114 @@
 package org.example.flowmod.engine;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Utilities for computing simple flow equations used by optimizers.
  */
-public class FlowPhysics {
+public final class FlowPhysics {
+    private static final double CD = 0.61;          // Discharge coefficient
+    private static final double RHO = 1000.0;       // kg/m^3
+    private static final double MU = 0.001;         // Pa.s
+    private static final double EPS = 4.5e-5;       // m, typical roughness
 
-    /**
-     * Dummy pressure drop calculation.
-     */
-    public double computePressureDrop(FlowParameters params) {
-        return params.flowRate() * 0.1;
+    public FlowPhysics() {
+    }
+
+    /** Volumetric flow through a circular orifice, L/s. */
+    public static double orificeFlowLps(double dMm, double deltaP_kPa) {
+        double d = dMm / 1000.0;
+        double area = Math.PI * d * d / 4.0;
+        double dp = deltaP_kPa * 1000.0;
+        double q = CD * area * Math.sqrt(2.0 * dp / RHO);
+        return q * 1000.0; // m^3/s to L/s
+    }
+
+    /** Pressure drop (kPa) required to get Q L/s through orifice d mm. */
+    public static double orificeDeltaP_kPa(double qLps, double dMm) {
+        double q = qLps / 1000.0;
+        double d = dMm / 1000.0;
+        double area = Math.PI * d * d / 4.0;
+        double v = q / (CD * area);
+        double dp = (v * v) * RHO / 2.0;
+        return dp / 1000.0;
+    }
+
+    /** Darcy–Weisbach friction head loss (kPa) for pipe section. */
+    public static double frictionDrop_kPa(double lengthMm, double idMm, double flowLps) {
+        double L = lengthMm / 1000.0;
+        double D = idMm / 1000.0;
+        double Q = flowLps / 1000.0;
+        if (Q <= 0.0 || D <= 0.0 || L <= 0.0) {
+            return 0.0;
+        }
+        double area = Math.PI * D * D / 4.0;
+        double v = Q / area;
+        double Re = RHO * v * D / MU;
+        double f;
+        if (Re <= 4000.0 && Re > 0) {
+            f = 64.0 / Re;
+        } else {
+            double term = EPS / (3.7 * D) + 5.74 / Math.pow(Re, 0.9);
+            f = 0.25 / Math.pow(Math.log10(term), 2.0);
+        }
+        double dp = f * (L / D) * (RHO * v * v / 2.0);
+        return dp / 1000.0;
+    }
+
+    /** Compute per-row flow for a HoleLayout, returning List<Double> L/s. */
+    public static List<Double> rowFlows(HoleLayout layout, FlowParameters p) {
+        List<HoleSpec> holes = layout.getHoles();
+        int n = holes.size();
+        if (n == 0) {
+            return List.of();
+        }
+        double spacing = p.headerLenMm() / (double) n;
+        double qTotal = p.flowLps();
+        double idMm = p.pipeDiameterMm();
+
+        double pLow = 0.001;
+        double pHigh = 1000.0;
+        List<Double> flows = null;
+        for (int iter = 0; iter < 40; iter++) {
+            double mid = (pLow + pHigh) / 2.0;
+            flows = computeFlowsForP0(mid, holes, spacing, idMm, qTotal);
+            double sum = flows.stream().mapToDouble(Double::doubleValue).sum();
+            if (sum > qTotal) {
+                pHigh = mid;
+            } else {
+                pLow = mid;
+            }
+        }
+        return flows == null ? List.of() : flows;
+    }
+
+    private static List<Double> computeFlowsForP0(double p0_kPa, List<HoleSpec> holes,
+                                                  double spacingMm, double idMm, double totalFlow) {
+        List<Double> result = new ArrayList<>();
+        double remaining = totalFlow;
+        double pressure = p0_kPa;
+        for (int i = 0; i < holes.size(); i++) {
+            if (i > 0) {
+                pressure -= frictionDrop_kPa(spacingMm, idMm, remaining);
+            }
+            double q = orificeFlowLps(holes.get(i).holeDiameterMm(), Math.max(pressure, 0.0));
+            q = Math.min(q, remaining);
+            result.add(q);
+            remaining -= q;
+        }
+        return result;
+    }
+
+    /** Return uniformity error (%CV) = 100*σ/μ across rows. */
+    public static double computeUniformityError(HoleLayout layout, FlowParameters p) {
+        List<Double> flows = rowFlows(layout, p);
+        if (flows.isEmpty()) {
+            return 0.0;
+        }
+        double mean = flows.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+        double variance = flows.stream().mapToDouble(f -> (f - mean) * (f - mean)).sum() / flows.size();
+        double sd = Math.sqrt(variance);
+        return mean == 0.0 ? 0.0 : (sd / mean) * 100.0;
     }
 }

--- a/src/main/java/org/example/flowmod/engine/GraduatedHoleOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/GraduatedHoleOptimizer.java
@@ -19,8 +19,8 @@ public class GraduatedHoleOptimizer {
     public HoleLayout optimize(FlowParameters params) {
         // Dummy implementation with a single hole
         HoleLayout layout = new HoleLayout();
-        double size = drillSizePolicy.getDrillSize(new HoleSpec(1.0, 0.0));
-        layout.addHole(new HoleSpec(size, 0.0));
+        double size = drillSizePolicy.getDrillSize(new HoleSpec(0, 1.0, 0.0));
+        layout.addHole(new HoleSpec(0, size, 0.0));
         return layout;
     }
 }

--- a/src/main/java/org/example/flowmod/engine/HoleSpec.java
+++ b/src/main/java/org/example/flowmod/engine/HoleSpec.java
@@ -1,6 +1,11 @@
 package org.example.flowmod.engine;
 
 /**
- * Specification for a flow modifier hole.
+ * Specification for a single row hole.
+ *
+ * @param rowIndex        zero-based row index along the header
+ * @param holeDiameterMm  drill diameter in millimetres
+ * @param angleDeg        angle of the hole in degrees
  */
-public record HoleSpec(double diameter, double position) {}
+public record HoleSpec(int rowIndex, double holeDiameterMm, double angleDeg) {
+}

--- a/src/main/java/org/example/flowmod/engine/RuleBasedHoleOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/RuleBasedHoleOptimizer.java
@@ -1,11 +1,15 @@
 package org.example.flowmod.engine;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Optimizer that applies user provided rules to generate a hole layout.
  */
 public class RuleBasedHoleOptimizer extends GraduatedHoleOptimizer {
 
     private final DesignRules designRules;
+    private static final Logger LOGGER = LoggerFactory.getLogger(RuleBasedHoleOptimizer.class);
 
     public RuleBasedHoleOptimizer(DesignRules rules, DrillSizePolicy policy, FlowPhysics physics) {
         super(policy, physics);
@@ -14,8 +18,21 @@ public class RuleBasedHoleOptimizer extends GraduatedHoleOptimizer {
 
     @Override
     public HoleLayout optimize(FlowParameters params) {
-        // In a real implementation designRules would influence the layout.
-        return super.optimize(params);
+        int rows = 10;
+        HoleLayout blank = new HoleLayout();
+        for (int i = 0; i < rows; i++) {
+            blank.addHole(new HoleSpec(i, 0.0, 0.0));
+        }
+
+        java.util.List<Double> drillSet = java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0);
+
+        HoleLayout layout = DrillUtils.taperWithRules(blank, drillSet, params);
+        double err = FlowPhysics.computeUniformityError(layout, params);
+        LOGGER.debug("Computed uniformity: {} %CV", err);
+        if (err > 5.0) {
+            throw new DesignNotConvergedException(String.format("Uniformity %.2f%% exceeds target", err));
+        }
+        return layout;
     }
 
     public DesignRules getDesignRules() {

--- a/src/test/java/org/example/flowmod/engine/FlowPhysicsTest.java
+++ b/src/test/java/org/example/flowmod/engine/FlowPhysicsTest.java
@@ -1,0 +1,23 @@
+package org.example.flowmod.engine;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FlowPhysicsTest {
+    @Test
+    public void testOrificeRoundTrip() {
+        double d = 10.0;
+        double q = 0.5;
+        double dp = FlowPhysics.orificeDeltaP_kPa(q, d);
+        double q2 = FlowPhysics.orificeFlowLps(d, dp);
+        assertEquals(q, q2, q * 0.01);
+    }
+
+    @Test
+    public void testFrictionDrop() {
+        double drop = FlowPhysics.frictionDrop_kPa(1000.0, 150.0, 6.0);
+        assertTrue(Math.abs(drop - 0.35) / 0.35 < 0.1);
+    }
+}

--- a/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
@@ -3,6 +3,7 @@ package org.example.flowmod.engine;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RuleBasedHoleOptimizerTest {
 
@@ -12,8 +13,14 @@ public class RuleBasedHoleOptimizerTest {
         FlowPhysics physics = new FlowPhysics();
         DesignRules rules = new DesignRules() {};
         RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
-        HoleLayout layout = optimizer.optimize(new FlowParameters(10.0, 1.0));
+        HoleLayout layout = optimizer.optimize(new FlowParameters(150.0, 6.309, 1200.0));
         assertNotNull(layout);
         assertNotNull(layout.getHoles());
+        double err1 = FlowPhysics.computeUniformityError(layout, new FlowParameters(150.0, 6.309, 1200.0));
+        assertTrue(err1 <= 5.0);
+
+        HoleLayout layout2 = optimizer.optimize(new FlowParameters(400.0, 31.5, 2000.0));
+        double err2 = FlowPhysics.computeUniformityError(layout2, new FlowParameters(400.0, 31.5, 2000.0));
+        assertTrue(err2 <= 5.0);
     }
 }


### PR DESCRIPTION
## Summary
- implement `FlowPhysics` with orifice and pipe friction calculations
- extend `FlowParameters` and `HoleSpec` records with design data
- add taper-based optimiser with SLF4J logging
- add helper algorithm `taperWithRules`
- expand unit tests for physics and optimiser behaviour

## Testing
- `gradlew test` *(fails: Invalid or corrupt jarfile)*