### PR TITLE
Fix build.gradle and regenerate Gradle wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java'
 }
 
- codex/create-engine-package-and-add-stubs
 
 java {
     toolchain {
@@ -10,19 +9,16 @@ java {
     }
 }
 
- main
 repositories {
     mavenCentral()
 }
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
- codex/create-engine-package-and-add-stubs
 
     implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation 'org.slf4j:slf4j-api:2.0.7'
     runtimeOnly 'org.slf4j:slf4j-simple:2.0.7'
- main
 }
 
 test {


### PR DESCRIPTION
## Summary
- clean up stray comment lines in `build.gradle`
- regenerate Gradle wrapper to restore missing JAR
- make `gradlew` executable

## Testing
- `gradle wrapper`
- `./gradlew --version --offline` *(fails: No route to host)*