### PR TITLE
Preserve row count when grouping drill operations

### DIFF
--- a/src/main/java/org/example/flowmod/engine/DrillUtils.java
+++ b/src/main/java/org/example/flowmod/engine/DrillUtils.java
@@ -58,13 +58,23 @@ public final class DrillUtils {
 
     private static HoleLayout minimiseDrillChanges(HoleLayout layout) {
         java.util.List<HoleSpec> result = new java.util.ArrayList<>();
-        HoleSpec prev = null;
+        java.util.List<HoleSpec> currentGroup = new java.util.ArrayList<>();
+        Double prevDiameter = null;
+
         for (HoleSpec h : layout.getHoles()) {
-            if (prev == null || Double.compare(prev.holeDiameterMm(), h.holeDiameterMm()) != 0) {
-                result.add(h);
-                prev = h;
+            double d = h.holeDiameterMm();
+            if (prevDiameter == null || Double.compare(prevDiameter, d) == 0) {
+                currentGroup.add(h);
+            } else {
+                // flush previous group before starting a new one
+                result.addAll(currentGroup);
+                currentGroup.clear();
+                currentGroup.add(h);
             }
+            prevDiameter = d;
         }
+
+        result.addAll(currentGroup);
         return toLayout(result);
     }
 

--- a/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RuleBasedHoleOptimizerTest {
 
@@ -16,10 +17,12 @@ public class RuleBasedHoleOptimizerTest {
         HoleLayout layout = optimizer.optimize(new FlowParameters(150.0, 6.309, 1200.0));
         assertNotNull(layout);
         assertNotNull(layout.getHoles());
+        assertEquals(10, layout.getHoles().size());
         double err1 = FlowPhysics.computeUniformityError(layout, new FlowParameters(150.0, 6.309, 1200.0));
         assertTrue(err1 <= 5.0);
 
         HoleLayout layout2 = optimizer.optimize(new FlowParameters(400.0, 31.5, 2000.0));
+        assertEquals(10, layout2.getHoles().size());
         double err2 = FlowPhysics.computeUniformityError(layout2, new FlowParameters(400.0, 31.5, 2000.0));
         assertTrue(err2 <= 5.0);
     }


### PR DESCRIPTION
## Summary
- refine drill change minimisation to group consecutive holes without dropping rows
- ensure optimizer tests verify row count remains constant

## Testing
- `./gradlew test` *(fails: Invalid or corrupt jarfile)*