### PR TITLE
Implement design rule support for hole optimizer

### DIFF
--- a/src/main/java/org/example/flowmod/engine/BasicDesignRules.java
+++ b/src/main/java/org/example/flowmod/engine/BasicDesignRules.java
@@ -1,0 +1,9 @@
+package org.example.flowmod.engine;
+
+import java.util.List;
+
+/**
+ * Simple immutable implementation of {@link DesignRules}.
+ */
+public record BasicDesignRules(int rowCount, List<Double> allowableDrillSizesMm) implements DesignRules {
+}

--- a/src/main/java/org/example/flowmod/engine/DesignRules.java
+++ b/src/main/java/org/example/flowmod/engine/DesignRules.java
@@ -1,7 +1,17 @@
 package org.example.flowmod.engine;
 
 /**
- * Marker interface for design rule configuration.
+ * Configuration interface supplying constraints for the optimiser.
  */
 public interface DesignRules {
+
+    /**
+     * Desired number of hole rows along the header.
+     */
+    int rowCount();
+
+    /**
+     * Allowed drill diameters in millimetres.
+     */
+    java.util.List<Double> allowableDrillSizesMm();
 }

--- a/src/main/java/org/example/flowmod/engine/RuleBasedHoleOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/RuleBasedHoleOptimizer.java
@@ -18,13 +18,19 @@ public class RuleBasedHoleOptimizer extends GraduatedHoleOptimizer {
 
     @Override
     public HoleLayout optimize(FlowParameters params) {
-        int rows = 10;
+        int rows = designRules.rowCount();
+        if (rows <= 0) {
+            rows = 1;
+        }
         HoleLayout blank = new HoleLayout();
         for (int i = 0; i < rows; i++) {
             blank.addHole(new HoleSpec(i, 0.0, 0.0));
         }
 
-        java.util.List<Double> drillSet = java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0);
+        java.util.List<Double> drillSet = designRules.allowableDrillSizesMm();
+        if (drillSet == null || drillSet.isEmpty()) {
+            drillSet = java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0);
+        }
 
         HoleLayout layout = DrillUtils.taperWithRules(blank, drillSet, params);
         double err = FlowPhysics.computeUniformityError(layout, params);

--- a/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
@@ -11,13 +11,19 @@ public class RuleBasedHoleOptimizerTest {
     public void testOptimizeReturnsLayout() {
         DrillSizePolicy policy = new DefaultDrillSizePolicy();
         FlowPhysics physics = new FlowPhysics();
-        DesignRules rules = new DesignRules() {};
+        DesignRules rules = new BasicDesignRules(10,
+                java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0));
         RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
         HoleLayout layout = optimizer.optimize(new FlowParameters(150.0, 6.309, 1200.0));
         assertNotNull(layout);
         assertNotNull(layout.getHoles());
         double err1 = FlowPhysics.computeUniformityError(layout, new FlowParameters(150.0, 6.309, 1200.0));
         assertTrue(err1 <= 5.0);
+
+        assertTrue(layout.getHoles().size() <= rules.rowCount());
+        for (HoleSpec h : layout.getHoles()) {
+            assertTrue(rules.allowableDrillSizesMm().contains(h.holeDiameterMm()));
+        }
 
         HoleLayout layout2 = optimizer.optimize(new FlowParameters(400.0, 31.5, 2000.0));
         double err2 = FlowPhysics.computeUniformityError(layout2, new FlowParameters(400.0, 31.5, 2000.0));


### PR DESCRIPTION
## Summary
- support config-driven rules in `DesignRules`
- add `BasicDesignRules` record to convey row count and drill set
- read those rules in `RuleBasedHoleOptimizer`
- expand unit test to ensure rules are respected

## Testing
- `sh gradlew test --no-daemon` *(fails: Invalid or corrupt jarfile)*