### PR TITLE
Fix Gradle plugins block and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Execute the test suite with:
 
 Test results are written to `build/reports/tests`.
 
+## Running the Application
+
+Launch the JavaFX interface with:
+
+```bash
+./gradlew run
+```
+
 ## License
 
 This project is licensed under the [Apache License 2.0](LICENSE).

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
+    id 'application'
     id 'java'
 }
-
 
 java {
     toolchain {
@@ -13,47 +13,23 @@ repositories {
     mavenCentral()
 }
 
+ext.fxVersion = '21.0.3'
+def os = org.gradle.internal.os.OperatingSystem.current().classifier
+
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
     implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation 'org.slf4j:slf4j-api:2.0.7'
     runtimeOnly 'org.slf4j:slf4j-simple:2.0.7'
+    implementation "org.openjfx:javafx-controls:$fxVersion"
+    runtimeOnly "org.openjfx:javafx-controls:$fxVersion:$os"
+    implementation "org.openjfx:javafx-graphics:$fxVersion"
+    runtimeOnly "org.openjfx:javafx-graphics:$fxVersion:$os"
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
 }
 
 test {
     useJUnitPlatform()
 }
-plugins {
-    id 'application'
-    id 'java'
-}
-
-java {
-    toolchain { languageVersion = JavaLanguageVersion.of(17) }   // keep
-}
-
-repositories { mavenCentral() }
-
-ext.fxVersion = '21.0.3'     
-def os = org.gradle.internal.os.OperatingSystem.current().classifier
-
-dependencies {
-    
-    implementation 'org.apache.commons:commons-math3:3.6.1'
-    implementation 'org.slf4j:slf4j-api:2.0.7'
-    runtimeOnly    'org.slf4j:slf4j-simple:2.0.7'
-
-    
-    implementation "org.openjfx:javafx-controls:$fxVersion"
-    runtimeOnly    "org.openjfx:javafx-controls:$fxVersion:$os"
-    implementation "org.openjfx:javafx-graphics:$fxVersion"
-    runtimeOnly    "org.openjfx:javafx-graphics:$fxVersion:$os"
-
-    
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
-}
-
-test { useJUnitPlatform() }
 
 application {
     mainClass = 'org.example.flowmod.app.FlowModApp'


### PR DESCRIPTION
## Summary
- merge duplicate plugins into a single block in `build.gradle`
- document how to run the JavaFX application with `./gradlew run`

## Testing
- `./gradlew test` *(fails: Unable to access gradle-wrapper.jar)*