### PR TITLE
Update JavaFX runtime classifier detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,16 +14,18 @@ repositories {
 }
 
 ext.fxVersion = '21.0.3'
-def os = org.gradle.internal.os.OperatingSystem.current().classifier
+def osDetector = org.gradle.internal.os.OperatingSystem.current()
+def platform = osDetector.isWindows() ? "win" :
+               osDetector.isMacOsX() ? "mac" : "linux"
 
 dependencies {
     implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation 'org.slf4j:slf4j-api:2.0.7'
     runtimeOnly 'org.slf4j:slf4j-simple:2.0.7'
     implementation "org.openjfx:javafx-controls:$fxVersion"
-    runtimeOnly "org.openjfx:javafx-controls:$fxVersion:$os"
+    runtimeOnly "org.openjfx:javafx-controls:$fxVersion:$platform"
     implementation "org.openjfx:javafx-graphics:$fxVersion"
-    runtimeOnly "org.openjfx:javafx-graphics:$fxVersion:$os"
+    runtimeOnly "org.openjfx:javafx-graphics:$fxVersion:$platform"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
 }
 


### PR DESCRIPTION
## Summary
- generate a `platform` string from the detected `OperatingSystem`
- use `platform` for JavaFX runtime dependencies

## Testing
- `./gradlew test` *(fails: Downloading https://services.gradle.org/distributions/gradle-8.7-all.zip: timeout)*