### PR TITLE
Fix minimiseDrillChanges early return

### DIFF
--- a/src/main/java/org/example/flowmod/engine/DrillUtils.java
+++ b/src/main/java/org/example/flowmod/engine/DrillUtils.java
@@ -57,9 +57,6 @@ public final class DrillUtils {
     }
 
     private static HoleLayout minimiseDrillChanges(HoleLayout layout) {
-       
-        return layout;
-
         java.util.List<HoleSpec> result = new java.util.ArrayList<>();
         java.util.List<HoleSpec> currentGroup = new java.util.ArrayList<>();
         Double prevDiameter = null;


### PR DESCRIPTION
## Summary
- remove early exit in `minimiseDrillChanges`

## Testing
- `./gradlew test` *(fails: No route to host)*