### PR TITLE
Implement default methods for DesignRules

### DIFF
--- a/src/main/java/org/example/flowmod/engine/DesignRules.java
+++ b/src/main/java/org/example/flowmod/engine/DesignRules.java
@@ -7,11 +7,19 @@ public interface DesignRules {
 
     /**
      * Desired number of hole rows along the header.
+     *
+     * @return maximum rows allowed
      */
-    int rowCount();
+    default int rowCount() {
+        return 10;
+    }
 
     /**
      * Allowed drill diameters in millimetres.
+     *
+     * @return list of permitted drill diameters
      */
-    java.util.List<Double> allowableDrillSizesMm();
+    default java.util.List<Double> allowableDrillSizesMm() {
+        return java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0);
+    }
 }


### PR DESCRIPTION
## Summary
- provide default implementation for `rowCount` and `allowableDrillSizesMm`

## Testing
- `./gradlew test` *(fails: No route to host)*