### PR TITLE
Remove Java toolchain specification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,6 @@ plugins {
     id 'java'
 }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
-
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
## Summary
- remove the Gradle toolchain block so Gradle can use the system JDK

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host when downloading Gradle wrapper)*