### PR TITLE
Fix JavaFX compile and runtime dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,19 +7,23 @@ repositories {
     mavenCentral()
 }
 
-ext.fxVersion = '21.0.3'
-def osDetector = org.gradle.internal.os.OperatingSystem.current()
-def platform = osDetector.isWindows() ? "win" :
-               osDetector.isMacOsX() ? "mac" : "linux"
 
 dependencies {
     implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation 'org.slf4j:slf4j-api:2.0.7'
     runtimeOnly 'org.slf4j:slf4j-simple:2.0.7'
-    implementation "org.openjfx:javafx-controls:$fxVersion"
-    runtimeOnly "org.openjfx:javafx-controls:$fxVersion:$platform"
+    def fxVersion = '21.0.3'
+    def os = org.gradle.internal.os.OperatingSystem.current().classifier
+
+    implementation "org.openjfx:javafx-base:$fxVersion"
     implementation "org.openjfx:javafx-graphics:$fxVersion"
-    runtimeOnly "org.openjfx:javafx-graphics:$fxVersion:$platform"
+    implementation "org.openjfx:javafx-controls:$fxVersion"
+    implementation "org.openjfx:javafx-fxml:$fxVersion"
+
+    runtimeOnly    "org.openjfx:javafx-base:$fxVersion:$os"
+    runtimeOnly    "org.openjfx:javafx-graphics:$fxVersion:$os"
+    runtimeOnly    "org.openjfx:javafx-controls:$fxVersion:$os"
+    runtimeOnly    "org.openjfx:javafx-fxml:$fxVersion:$os"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
 }
 


### PR DESCRIPTION
## Summary
- add JavaFX base, graphics, controls, and fxml modules for compilation
- include matching runtime artifacts for the current OS
- remove old platform detection lines

## Testing
- `./gradlew help --no-daemon` *(fails: No route to host)*