### PR TITLE
Update build.gradle with JavaFX plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'application'
     id 'java'
+    id 'org.openjfx.javafxplugin' version '0.0.14'
 }
 
 repositories {
@@ -12,23 +13,6 @@ dependencies {
     implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation 'org.slf4j:slf4j-api:2.0.7'
     runtimeOnly 'org.slf4j:slf4j-simple:2.0.7'
-    def fxVersion = '21.0.3'
-    def currentOs = org.gradle.internal.os.OperatingSystem.current()
-    def os
-    if (currentOs.isWindows()) {
-        os = 'win'
-    } else if (currentOs.isMacOsX()) {
-        os = 'mac'
-    } else if (currentOs.isLinux()) {
-        os = 'linux'
-    } else {
-        throw new GradleException("Unsupported operating system: $currentOs")
-    }
-
-    implementation "org.openjfx:javafx-base:$fxVersion:$os"
-    implementation "org.openjfx:javafx-graphics:$fxVersion:$os"
-    implementation "org.openjfx:javafx-controls:$fxVersion:$os"
-    implementation "org.openjfx:javafx-fxml:$fxVersion:$os"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
 }
 
@@ -38,4 +22,9 @@ test {
 
 application {
     mainClass = 'org.example.flowmod.app.FlowModApp'
+}
+
+javafx {
+    version = '21.0.3'
+    modules = ['javafx.controls', 'javafx.fxml']
 }


### PR DESCRIPTION
## Summary
- add `org.openjfx.javafxplugin` to Gradle plugins
- remove manual platform detection and JavaFX dependencies
- configure `javafx` block after the `application` block

## Testing
- `./gradlew run` *(fails: No route to host while downloading Gradle)*
- `./gradlew test` *(fails: No route to host while downloading Gradle)*