### PR TITLE
Unify row spacing logic

### DIFF
--- a/src/main/java/org/example/flowmod/engine/FlowPhysics.java
+++ b/src/main/java/org/example/flowmod/engine/FlowPhysics.java
@@ -70,7 +70,7 @@ public final class FlowPhysics {
         if (n == 0) {
             return List.of();
         }
-        double spacing = p.headerLenMm() / (double) n;
+        double spacing = DesignRules.DEFAULT_ROW_SPACING_MM;
         double qTotal = p.flowLps();
         double idMm = p.pipeDiameterMm();
 

--- a/src/main/java/org/example/flowmod/engine/RuleBasedHoleOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/RuleBasedHoleOptimizer.java
@@ -18,7 +18,8 @@ public class RuleBasedHoleOptimizer extends GraduatedHoleOptimizer {
 
     @Override
     public HoleLayout optimize(FlowParameters params) {
-        int rows = designRules.rowCount();
+        int rows = (int) Math.floor(params.headerLenMm() /
+                DesignRules.DEFAULT_ROW_SPACING_MM);
         if (rows <= 0) {
             rows = 1;
         }

--- a/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
@@ -17,21 +17,23 @@ public class RuleBasedHoleOptimizerTest {
         DesignRules rules = new BasicDesignRules(10,
                 java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0));
         RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
-        HoleLayout layout = optimizer.optimize(new FlowParameters(150.0, 6.309, 1200.0));
+        FlowParameters p1 = new FlowParameters(150.0, 6.309, 1200.0);
+        HoleLayout layout = optimizer.optimize(p1);
         assertNotNull(layout);
         assertNotNull(layout.getHoles());
-        assertEquals(10, layout.getHoles().size());
-        double err1 = FlowPhysics.computeUniformityError(layout, new FlowParameters(150.0, 6.309, 1200.0));
+        int expectedRows1 = (int) Math.floor(p1.headerLenMm() / DesignRules.DEFAULT_ROW_SPACING_MM);
+        assertEquals(expectedRows1, layout.getHoles().size());
+        double err1 = FlowPhysics.computeUniformityError(layout, p1);
         assertTrue(err1 <= 5.0);
-
-        assertTrue(layout.getHoles().size() <= rules.rowCount());
         for (HoleSpec h : layout.getHoles()) {
             assertTrue(rules.allowableDrillSizesMm().contains(h.holeDiameterMm()));
         }
 
-        HoleLayout layout2 = optimizer.optimize(new FlowParameters(400.0, 31.5, 2000.0));
-        assertEquals(10, layout2.getHoles().size());
-        double err2 = FlowPhysics.computeUniformityError(layout2, new FlowParameters(400.0, 31.5, 2000.0));
+        FlowParameters p2 = new FlowParameters(400.0, 31.5, 2000.0);
+        HoleLayout layout2 = optimizer.optimize(p2);
+        int expectedRows2 = (int) Math.floor(p2.headerLenMm() / DesignRules.DEFAULT_ROW_SPACING_MM);
+        assertEquals(expectedRows2, layout2.getHoles().size());
+        double err2 = FlowPhysics.computeUniformityError(layout2, p2);
         assertTrue(err2 <= 5.0);
     }
 
@@ -42,8 +44,10 @@ public class RuleBasedHoleOptimizerTest {
         DesignRules rules = new DesignRules() {};
         RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
 
-        HoleLayout layout = optimizer.optimize(new FlowParameters(200.0, 10.0, 1500.0));
+        FlowParameters p = new FlowParameters(200.0, 10.0, 1500.0);
+        HoleLayout layout = optimizer.optimize(p);
         assertNotNull(layout);
-        assertEquals(10, layout.getHoles().size());
+        int expectedRows = (int) Math.floor(p.headerLenMm() / DesignRules.DEFAULT_ROW_SPACING_MM);
+        assertEquals(expectedRows, layout.getHoles().size());
     }
 }


### PR DESCRIPTION
## Summary
- base row count on constant spacing
- use the same spacing in flow calculations
- adjust optimizer tests for new row count

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*