### PR TITLE
Add header mode selection

### DIFF
--- a/src/main/java/org/example/flowmod/app/MainController.java
+++ b/src/main/java/org/example/flowmod/app/MainController.java
@@ -11,6 +11,7 @@ import java.io.PrintWriter;
 public final class MainController {
 
     @FXML private TextField pipeField, flowField, lenField;
+    @FXML private ChoiceBox<String> modeChoice;
     @FXML private Button designBtn, exportCsvBtn, exportSvgBtn;
     @FXML private TableView<HoleSpec> table;
     @FXML private TableColumn<HoleSpec, Number> posCol, rowCol, diaCol;
@@ -28,6 +29,9 @@ public final class MainController {
                 c.getValue().axialPosMm()));
         rowCol.setCellValueFactory(c -> new SimpleDoubleProperty(c.getValue().rowIndex()));
         diaCol.setCellValueFactory(c -> new SimpleDoubleProperty(c.getValue().holeDiameterMm()));
+        if (modeChoice != null) {
+            modeChoice.getSelectionModel().selectFirst();
+        }
     }
 
     @FXML
@@ -38,7 +42,11 @@ public final class MainController {
             double len  = Double.parseDouble(lenField.getText());
 
             double lps = gpm * 0.0631;   // GPM → L/s
-            FlowParameters p = new FlowParameters(id, lps, len);
+            HeaderType mode = HeaderType.PRESSURE;
+            if (modeChoice != null && "Suction".equalsIgnoreCase(modeChoice.getValue())) {
+                mode = HeaderType.SUCTION;
+            }
+            FlowParameters p = new FlowParameters(id, lps, len, mode);
 
             layout = optimizer.optimize(p);
 

--- a/src/main/java/org/example/flowmod/engine/FlowParameters.java
+++ b/src/main/java/org/example/flowmod/engine/FlowParameters.java
@@ -6,6 +6,10 @@ package org.example.flowmod.engine;
  * @param pipeDiameterMm internal pipe diameter in millimetres
  * @param flowLps        total volumetric flow supplied to the header in litres per second
  * @param headerLenMm    header length in millimetres
+ * @param headerType     operating mode of the header
  */
-public record FlowParameters(double pipeDiameterMm, double flowLps, double headerLenMm) {
+public record FlowParameters(double pipeDiameterMm,
+                             double flowLps,
+                             double headerLenMm,
+                             HeaderType headerType) {
 }

--- a/src/main/java/org/example/flowmod/engine/FlowPhysics.java
+++ b/src/main/java/org/example/flowmod/engine/FlowPhysics.java
@@ -71,11 +71,7 @@ public final class FlowPhysics {
             return List.of();
         }
 
-        double spacing = DesignRules.DEFAULT_ROW_SPACING_MM;
-        double qTotal = p.flowLps();
-
         double spacing = p.headerLenMm() / (double) n;
-
         double idMm = p.pipeDiameterMm();
 
         double[] flowsArr = new double[n];
@@ -85,12 +81,22 @@ public final class FlowPhysics {
         // iterate from blind end toward the supply end
         for (int i = n - 1; i >= 0; i--) {
             HoleSpec hole = holes.get(i);
-            double holeFlow = orificeFlowLps(hole.holeDiameterMm(), -pressure);
+            double holeFlow;
+            if (p.headerType() == HeaderType.PRESSURE) {
+                holeFlow = orificeFlowLps(hole.holeDiameterMm(), pressure);
+            } else {
+                holeFlow = orificeFlowLps(hole.holeDiameterMm(), -pressure);
+            }
             flowsArr[i] = holeFlow;
             pipeFlow += holeFlow;
 
             if (i > 0) {
-                pressure -= frictionDrop_kPa(spacing, idMm, pipeFlow);
+                double drop = frictionDrop_kPa(spacing, idMm, pipeFlow);
+                if (p.headerType() == HeaderType.PRESSURE) {
+                    pressure += drop;
+                } else {
+                    pressure -= drop;
+                }
             }
         }
 

--- a/src/main/java/org/example/flowmod/engine/HeaderType.java
+++ b/src/main/java/org/example/flowmod/engine/HeaderType.java
@@ -1,0 +1,7 @@
+package org.example.flowmod.engine;
+
+/** Represents whether the header operates under pressure or suction. */
+public enum HeaderType {
+    PRESSURE,
+    SUCTION;
+}

--- a/src/main/resources/layout/MainView.fxml
+++ b/src/main/resources/layout/MainView.fxml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?import javafx.scene.*?>
 <?import javafx.scene.control.*?>
+<?import javafx.collections.FXCollections?>
 <?import javafx.scene.layout.*?>
 
 <BorderPane xmlns:fx="http://javafx.com/fxml"
@@ -14,6 +15,15 @@
             <TextField fx:id="flowField" promptText="100"/>
             <Label text="Header length mm"/>
             <TextField fx:id="lenField" promptText="1200"/>
+            <Label text="Mode"/>
+            <ChoiceBox fx:id="modeChoice">
+                <items>
+                    <FXCollections fx:factory="observableArrayList">
+                        <String fx:value="Pressure"/>
+                        <String fx:value="Suction"/>
+                    </FXCollections>
+                </items>
+            </ChoiceBox>
             <Button fx:id="designBtn" text="Design" onAction="#onDesign"/>
         </VBox>
     </left>

--- a/src/test/java/org/example/flowmod/engine/DrillUtilsTest.java
+++ b/src/test/java/org/example/flowmod/engine/DrillUtilsTest.java
@@ -14,7 +14,7 @@ public class DrillUtilsTest {
             blank.addHole(new HoleSpec(i, 0.0, 0.0));
         }
         java.util.List<Double> drillSet = java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0);
-        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0);
+        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0, HeaderType.PRESSURE);
 
         HoleLayout layout = DrillUtils.taperWithRules(blank, drillSet, params);
         assertEquals(rows, layout.getHoles().size());
@@ -30,7 +30,7 @@ public class DrillUtilsTest {
             blank.addHole(new HoleSpec(i, 0.0, 0.0));
         }
         java.util.List<Double> drillSet = java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0);
-        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0);
+        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0, HeaderType.PRESSURE);
 
         HoleLayout layout = DrillUtils.taperWithRules(blank, drillSet, params);
         double prev = 0.0;
@@ -48,7 +48,7 @@ public class DrillUtilsTest {
             blank.addHole(new HoleSpec(i, 0.0, 0.0));
         }
         java.util.List<Double> drillSet = java.util.List.of(16.0);
-        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0);
+        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0, HeaderType.PRESSURE);
 
         HoleLayout layout = DrillUtils.taperWithRules(blank, drillSet, params);
         for (HoleSpec h : layout.getHoles()) {

--- a/src/test/java/org/example/flowmod/engine/FlowPhysicsTest.java
+++ b/src/test/java/org/example/flowmod/engine/FlowPhysicsTest.java
@@ -31,7 +31,7 @@ public class FlowPhysicsTest {
     public void testComputeReynolds() {
         double gpm = 100.0;
         double lps = gpm * 0.0631;
-        FlowParameters p = new FlowParameters(150.0, lps, 1000.0);
+        FlowParameters p = new FlowParameters(150.0, lps, 1000.0, HeaderType.PRESSURE);
         double Re = FlowPhysics.computeReynolds(p);
         assertEquals(1.9e5, Re, 2e4);
     }

--- a/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
@@ -17,7 +17,7 @@ public class RuleBasedHoleOptimizerTest {
         DesignRules rules = new BasicDesignRules(10,
                 java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0));
         RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
-        FlowParameters p1 = new FlowParameters(150.0, 6.309, 1200.0);
+        FlowParameters p1 = new FlowParameters(150.0, 6.309, 1200.0, HeaderType.PRESSURE);
         HoleLayout layout = optimizer.optimize(p1);
         assertNotNull(layout);
         assertNotNull(layout.getHoles());
@@ -29,7 +29,7 @@ public class RuleBasedHoleOptimizerTest {
             assertTrue(rules.allowableDrillSizesMm().contains(h.holeDiameterMm()));
         }
 
-        FlowParameters p2 = new FlowParameters(400.0, 31.5, 2000.0);
+        FlowParameters p2 = new FlowParameters(400.0, 31.5, 2000.0, HeaderType.PRESSURE);
         HoleLayout layout2 = optimizer.optimize(p2);
         int expectedRows2 = (int) Math.floor(p2.headerLenMm() / DesignRules.DEFAULT_ROW_SPACING_MM);
         assertEquals(expectedRows2, layout2.getHoles().size());
@@ -44,7 +44,7 @@ public class RuleBasedHoleOptimizerTest {
         DesignRules rules = new DesignRules() {};
         RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
 
-        FlowParameters p = new FlowParameters(200.0, 10.0, 1500.0);
+        FlowParameters p = new FlowParameters(200.0, 10.0, 1500.0, HeaderType.PRESSURE);
         HoleLayout layout = optimizer.optimize(p);
         assertNotNull(layout);
         int expectedRows = (int) Math.floor(p.headerLenMm() / DesignRules.DEFAULT_ROW_SPACING_MM);


### PR DESCRIPTION
## Summary
- allow user to select `Pressure` or `Suction` mode in the UI
- carry selected mode in `FlowParameters`
- update `FlowPhysics.rowFlows` to account for header type
- adjust `MainController` to read mode selection
- update tests for new `FlowParameters` constructor

## Testing
- `./gradlew test --quiet` *(fails: No route to host while downloading gradle)*