### PR TITLE
Fix duplicate variable in rowFlows

### DIFF
--- a/src/main/java/org/example/flowmod/engine/FlowPhysics.java
+++ b/src/main/java/org/example/flowmod/engine/FlowPhysics.java
@@ -71,9 +71,6 @@ public final class FlowPhysics {
             return List.of();
         }
 
-        double spacing = DesignRules.DEFAULT_ROW_SPACING_MM;
-        double qTotal = p.flowLps();
-
         double spacing = p.headerLenMm() / (double) n;
 
         double idMm = p.pipeDiameterMm();


### PR DESCRIPTION
## Summary
- remove duplicate spacing variable and unused qTotal

## Testing
- `./gradlew test` *(fails: No route to host)*