### PR TITLE
Fix design defaults and handle blank input

### DIFF
--- a/src/main/java/org/example/flowmod/app/MainController.java
+++ b/src/main/java/org/example/flowmod/app/MainController.java
@@ -34,12 +34,20 @@ public final class MainController {
         }
     }
 
+    private static double parseDoubleField(TextField field) {
+        String text = field.getText();
+        if (text == null || text.isBlank()) {
+            text = field.getPromptText();
+        }
+        return Double.parseDouble(text);
+    }
+
     @FXML
     private void onDesign() {
         try {
-            double id   = Double.parseDouble(pipeField.getText());
-            double gpm  = Double.parseDouble(flowField.getText());
-            double len  = Double.parseDouble(lenField.getText());
+            double id   = parseDoubleField(pipeField);
+            double gpm  = parseDoubleField(flowField);
+            double len  = parseDoubleField(lenField);
 
             double lps = gpm * 0.0631;   // GPM → L/s
             HeaderType mode = HeaderType.PRESSURE;


### PR DESCRIPTION
## Summary
- avoid empty input causing design to fail by adding `parseDoubleField`
- use prompt text values when text fields are blank

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*