### PR TITLE
Stabilise flow solver

### DIFF
--- a/src/main/java/org/example/flowmod/app/MainController.java
+++ b/src/main/java/org/example/flowmod/app/MainController.java
@@ -87,8 +87,9 @@ public final class MainController {
                     circumference, p.headerLenMm()));
         } catch (DesignNotConvergedException ex) {
             table.getItems().clear();
+            uniLabel.setText(ex.getMessage());
+            uniLabel.setStyle("-fx-text-fill: red;");
             LOGGER.error("Design failed", ex);
-            showError("Design failed: " + ex.getMessage());
         } catch (Exception ex) {
             table.getItems().clear();
             LOGGER.error("Invalid input", ex);

--- a/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
@@ -50,4 +50,35 @@ public class RuleBasedHoleOptimizerTest {
         int expectedRows = (int) Math.floor(p.headerLenMm() / DesignRules.DEFAULT_ROW_SPACING_MM);
         assertEquals(expectedRows, layout.getHoles().size());
     }
+
+    @Test
+    public void testHighFlowUniformity() {
+        DrillSizePolicy policy = new DefaultDrillSizePolicy();
+        FlowPhysics physics = new FlowPhysics();
+        DesignRules rules = new BasicDesignRules(10,
+                java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0));
+        RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
+
+        double lps = 120.0 * 0.0631;
+        FlowParameters p = new FlowParameters(200.0, lps, 1300.0, HeaderType.PRESSURE);
+        HoleLayout layout = optimizer.optimize(p);
+        double err = FlowPhysics.computeUniformityError(layout, p);
+        assertTrue(err <= 5.0, "Uniformity too high: " + err);
+    }
+
+    @Test
+    public void testPathologicalCaseFailsQuickly() {
+        DrillSizePolicy policy = new DefaultDrillSizePolicy();
+        FlowPhysics physics = new FlowPhysics();
+        DesignRules rules = new BasicDesignRules(10,
+                java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0));
+        RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
+
+        double lps = 1000.0 * 0.0631;
+        FlowParameters p = new FlowParameters(50.0, lps, 100.0, HeaderType.PRESSURE);
+
+        java.time.Duration timeout = java.time.Duration.ofSeconds(5);
+        org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(timeout, () ->
+                assertThrows(DesignNotConvergedException.class, () -> optimizer.optimize(p)));
+    }
 }


### PR DESCRIPTION
## Summary
- switch `FlowPhysics.rowFlows` to Levenberg–Marquardt least squares solver
- let `DrillUtils.taperWithRules` retry with coarser pattern when convergence fails
- show failure message in UI when design does not converge
- add regression tests for successful and failing optimization cases

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*