### PR TITLE
Remove LM optimizer iteration limits

### DIFF
--- a/src/main/java/org/example/flowmod/engine/FlowPhysics.java
+++ b/src/main/java/org/example/flowmod/engine/FlowPhysics.java
@@ -122,9 +122,7 @@ public final class FlowPhysics {
         };
 
         org.apache.commons.math3.fitting.leastsquares.LevenbergMarquardtOptimizer optimizer =
-                new org.apache.commons.math3.fitting.leastsquares.LevenbergMarquardtOptimizer()
-                        .withMaxIterations(50)
-                        .withMaxEvaluations(50);
+                new org.apache.commons.math3.fitting.leastsquares.LevenbergMarquardtOptimizer();
 
         org.apache.commons.math3.fitting.leastsquares.MultivariateJacobianFunction model =
                 (org.apache.commons.math3.linear.RealVector point) -> {


### PR DESCRIPTION
## Summary
- simplify `FlowPhysics` by dropping optimizer iteration limit parameters

## Testing
- `./gradlew --offline test` *(fails: unable to download Gradle wrapper due to no network)*