### PR TITLE
Improve hole position calculations

### DIFF
--- a/src/main/java/org/example/flowmod/engine/DrillUtils.java
+++ b/src/main/java/org/example/flowmod/engine/DrillUtils.java
@@ -7,8 +7,8 @@ public final class DrillUtils {
     private DrillUtils() {
     }
 
-    public static HoleSpec createHole(int rowIndex, double diameterMm, double angleDeg) {
-        return new HoleSpec(rowIndex, diameterMm, angleDeg);
+    public static HoleSpec createHole(int rowIndex, double diameterMm, double angleDeg, double spacingMm) {
+        return new HoleSpec(rowIndex, diameterMm, angleDeg, spacingMm);
     }
 
     /**
@@ -27,7 +27,7 @@ public final class DrillUtils {
         double largest = sizes.get(0);
         for (int i = 0; i < holes.size(); i++) {
             HoleSpec h = holes.get(i);
-            holes.set(i, new HoleSpec(h.rowIndex(), largest, h.angleDeg()));
+            holes.set(i, new HoleSpec(h.rowIndex(), largest, h.angleDeg(), h.spacingMm()));
         }
 
         HoleLayout layout = toLayout(holes);
@@ -57,7 +57,7 @@ public final class DrillUtils {
 
             HoleSpec h = holes.get(idx);
             int pos = sizes.indexOf(h.holeDiameterMm());
-            holes.set(idx, new HoleSpec(h.rowIndex(), sizes.get(pos + 1), h.angleDeg()));
+            holes.set(idx, new HoleSpec(h.rowIndex(), sizes.get(pos + 1), h.angleDeg(), h.spacingMm()));
             layout = toLayout(holes);
         }
 

--- a/src/main/java/org/example/flowmod/engine/GraduatedHoleOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/GraduatedHoleOptimizer.java
@@ -19,8 +19,9 @@ public class GraduatedHoleOptimizer {
     public HoleLayout optimize(FlowParameters params) {
         // Dummy implementation with a single hole
         HoleLayout layout = new HoleLayout();
-        double size = drillSizePolicy.getDrillSize(new HoleSpec(0, 1.0, 0.0));
-        layout.addHole(new HoleSpec(0, size, 0.0));
+        double spacing = params.headerLenMm();
+        double size = drillSizePolicy.getDrillSize(new HoleSpec(0, 1.0, 0.0, spacing));
+        layout.addHole(new HoleSpec(0, size, 0.0, spacing));
         return layout;
     }
 }

--- a/src/main/java/org/example/flowmod/engine/HoleSpec.java
+++ b/src/main/java/org/example/flowmod/engine/HoleSpec.java
@@ -6,9 +6,17 @@ package org.example.flowmod.engine;
  * @param rowIndex        zero-based row index along the header
  * @param holeDiameterMm  drill diameter in millimetres
  * @param angleDeg        angle of the hole in degrees
+ * @param spacingMm       distance between rows in millimetres
  */
-public record HoleSpec(int rowIndex, double holeDiameterMm, double angleDeg) {
+public record HoleSpec(int rowIndex,
+                       double holeDiameterMm,
+                       double angleDeg,
+                       double spacingMm) {
+
+    /**
+     * Axial position of the hole centre along the header, millimetres.
+     */
     public double axialPosMm() {
-        return rowIndex * DesignRules.DEFAULT_ROW_SPACING_MM;
+        return rowIndex * spacingMm;
     }
 }

--- a/src/main/java/org/example/flowmod/engine/RuleBasedHoleOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/RuleBasedHoleOptimizer.java
@@ -23,9 +23,10 @@ public class RuleBasedHoleOptimizer extends GraduatedHoleOptimizer {
         if (rows <= 0) {
             rows = 1;
         }
+        double spacing = params.headerLenMm() / (double) rows;
         HoleLayout blank = new HoleLayout();
         for (int i = 0; i < rows; i++) {
-            blank.addHole(new HoleSpec(i, 0.0, 0.0));
+            blank.addHole(new HoleSpec(i, 0.0, 0.0, spacing));
         }
 
         java.util.List<Double> drillSet = designRules.allowableDrillSizesMm();

--- a/src/test/java/org/example/flowmod/engine/DrillUtilsTest.java
+++ b/src/test/java/org/example/flowmod/engine/DrillUtilsTest.java
@@ -10,8 +10,9 @@ public class DrillUtilsTest {
     public void testTaperWithRulesUniformity() {
         int rows = 10;
         HoleLayout blank = new HoleLayout();
+        double spacing = 1200.0 / rows;
         for (int i = 0; i < rows; i++) {
-            blank.addHole(new HoleSpec(i, 0.0, 0.0));
+            blank.addHole(new HoleSpec(i, 0.0, 0.0, spacing));
         }
         java.util.List<Double> drillSet = java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0);
         FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0, HeaderType.PRESSURE);
@@ -26,8 +27,9 @@ public class DrillUtilsTest {
     public void testTaperWithRulesMonotonicDiameters() {
         int rows = 10;
         HoleLayout blank = new HoleLayout();
+        double spacing = 1200.0 / rows;
         for (int i = 0; i < rows; i++) {
-            blank.addHole(new HoleSpec(i, 0.0, 0.0));
+            blank.addHole(new HoleSpec(i, 0.0, 0.0, spacing));
         }
         java.util.List<Double> drillSet = java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0);
         FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0, HeaderType.PRESSURE);
@@ -44,8 +46,9 @@ public class DrillUtilsTest {
     public void testTaperWithRulesNoAvailableReduction() {
         int rows = 5;
         HoleLayout blank = new HoleLayout();
+        double spacing = 1200.0 / rows;
         for (int i = 0; i < rows; i++) {
-            blank.addHole(new HoleSpec(i, 0.0, 0.0));
+            blank.addHole(new HoleSpec(i, 0.0, 0.0, spacing));
         }
         java.util.List<Double> drillSet = java.util.List.of(16.0);
         FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0, HeaderType.PRESSURE);
@@ -62,8 +65,9 @@ public class DrillUtilsTest {
     public void testTaperHighFlowMultipleSizes() {
         int rows = (int) Math.floor(1300.0 / DesignRules.DEFAULT_ROW_SPACING_MM);
         HoleLayout blank = new HoleLayout();
+        double spacing = 1300.0 / rows;
         for (int i = 0; i < rows; i++) {
-            blank.addHole(new HoleSpec(i, 0.0, 0.0));
+            blank.addHole(new HoleSpec(i, 0.0, 0.0, spacing));
         }
         java.util.List<Double> drillSet = java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0);
 

--- a/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerRuntimeTest.java
+++ b/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerRuntimeTest.java
@@ -23,5 +23,8 @@ public class RuleBasedHoleOptimizerRuntimeTest {
 
         double err = FlowPhysics.computeUniformityError(layout, p);
         assertTrue(err <= 5.0);
+        HoleSpec last = layout.getHoles().get(layout.getHoles().size() - 1);
+        double spacing = p.headerLenMm() / layout.getHoles().size();
+        assertEquals(p.headerLenMm(), last.axialPosMm() + spacing, spacing * 0.01);
     }
 }

--- a/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
@@ -28,6 +28,9 @@ public class RuleBasedHoleOptimizerTest {
         for (HoleSpec h : layout.getHoles()) {
             assertTrue(rules.allowableDrillSizesMm().contains(h.holeDiameterMm()));
         }
+        HoleSpec last1 = layout.getHoles().get(layout.getHoles().size() - 1);
+        double spacing1 = p1.headerLenMm() / layout.getHoles().size();
+        assertEquals(p1.headerLenMm(), last1.axialPosMm() + spacing1, spacing1 * 0.01);
 
         FlowParameters p2 = new FlowParameters(400.0, 31.5, 2000.0, HeaderType.PRESSURE);
         HoleLayout layout2 = optimizer.optimize(p2);
@@ -35,6 +38,9 @@ public class RuleBasedHoleOptimizerTest {
         assertEquals(expectedRows2, layout2.getHoles().size());
         double err2 = FlowPhysics.computeUniformityError(layout2, p2);
         assertTrue(err2 <= 5.0);
+        HoleSpec last2 = layout2.getHoles().get(layout2.getHoles().size() - 1);
+        double spacing2 = p2.headerLenMm() / layout2.getHoles().size();
+        assertEquals(p2.headerLenMm(), last2.axialPosMm() + spacing2, spacing2 * 0.01);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- include row spacing in `HoleSpec`
- compute spacing from header length in `RuleBasedHoleOptimizer`
- pass spacing to hole helpers and optimisers
- update JavaFX controller and exports implicitly use new positions
- check final hole position in optimiser tests

## Testing
- `./gradlew test --offline` *(fails: No route to host)*