### PR TITLE
Rollback supply pressure and add suction solver

### DIFF
--- a/src/main/java/org/example/flowmod/app/MainController.java
+++ b/src/main/java/org/example/flowmod/app/MainController.java
@@ -14,7 +14,7 @@ public final class MainController {
 
     private static final Logger log = LoggerFactory.getLogger(MainController.class);
 
-    @FXML private TextField pipeField, flowField, lenField, pressureField;
+    @FXML private TextField pipeField, flowField, lenField;
     @FXML private ChoiceBox<String> modeChoice;
     @FXML private Button designBtn, exportCsvBtn, exportSvgBtn;
     @FXML private TableView<HoleSpec> table;
@@ -63,16 +63,11 @@ public final class MainController {
             double id   = parseDoubleField(pipeField);
             double gpm  = parseDoubleField(flowField);
             double len  = parseDoubleField(lenField);
-            double press = parseDoubleField(pressureField);
 
-            log.debug("Parsed input: id={} flow={} len={} pressure={}", id, gpm, len, press);
+            log.debug("Parsed input: id={} flow={} len={}", id, gpm, len);
 
             double lps = gpm * 0.0631;   // GPM → L/s
-            HeaderType mode = HeaderType.PRESSURE;
-            if (modeChoice != null && "Suction".equalsIgnoreCase(modeChoice.getValue())) {
-                mode = HeaderType.SUCTION;
-            }
-            FlowParameters p = new FlowParameters(id, lps, len, press, mode);
+            FlowParameters p = new FlowParameters(id, lps, len);
             log.debug("Constructed parameters: {}", p);
 
             layout = optimizer.optimize(p);

--- a/src/main/java/org/example/flowmod/engine/DrillUtils.java
+++ b/src/main/java/org/example/flowmod/engine/DrillUtils.java
@@ -34,8 +34,14 @@ public final class DrillUtils {
         final double target = 5.0;
 
         while (true) {
-            java.util.List<Double> flows = FlowPhysics.rowFlows(layout, p);
-            double err = FlowPhysics.computeUniformityError(layout, p);
+            double suction = FlowPhysics.findRequiredSuctionKPa(layout, p, -100.0, -1.0);
+            java.util.List<Double> flows = FlowPhysics.rowFlows(layout, p, suction);
+            org.apache.commons.math3.stat.descriptive.DescriptiveStatistics stats =
+                    new org.apache.commons.math3.stat.descriptive.DescriptiveStatistics();
+            for (double q : flows) {
+                stats.addValue(q);
+            }
+            double err = 100 * stats.getStandardDeviation() / stats.getMean();
             if (err <= target) {
                 break;
             }

--- a/src/main/java/org/example/flowmod/engine/FlowParameters.java
+++ b/src/main/java/org/example/flowmod/engine/FlowParameters.java
@@ -6,11 +6,8 @@ package org.example.flowmod.engine;
  * @param pipeDiameterMm internal pipe diameter in millimetres
  * @param flowLps        total volumetric flow supplied to the header in litres per second
  * @param headerLenMm    header length in millimetres
- * @param headerType     operating mode of the header
  */
 public record FlowParameters(double pipeDiameterMm,
                              double flowLps,
-                             double headerLenMm,
-                             double supplyPressureKPa,
-                             HeaderType headerType) {
+                             double headerLenMm) {
 }

--- a/src/main/resources/layout/MainView.fxml
+++ b/src/main/resources/layout/MainView.fxml
@@ -16,8 +16,6 @@
             <TextField fx:id="flowField" promptText="100"/>
             <Label text="Header length mm"/>
             <TextField fx:id="lenField" promptText="1200"/>
-            <Label text="Supply pressure kPa"/>
-            <TextField fx:id="pressureField" promptText="100"/>
             <Label text="Mode"/>
             <ChoiceBox fx:id="modeChoice">
                 <items>

--- a/src/test/java/org/example/flowmod/engine/DrillUtilsTest.java
+++ b/src/test/java/org/example/flowmod/engine/DrillUtilsTest.java
@@ -15,12 +15,11 @@ public class DrillUtilsTest {
             blank.addHole(new HoleSpec(i, 0.0, 0.0, spacing));
         }
         java.util.List<Double> drillSet = java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0);
-        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0, 100.0, HeaderType.PRESSURE);
+        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0);
 
         HoleLayout layout = DrillUtils.taperWithRules(blank, drillSet, params);
         assertEquals(rows, layout.getHoles().size());
-        FlowParameters tuned = FlowPhysics.balanceSupplyPressure(layout, params);
-        double err = FlowPhysics.computeUniformityError(layout, tuned);
+        double err = FlowPhysics.computeUniformityError(layout, params);
         assertTrue(err <= 5.0, "Uniformity error too high: " + err);
     }
 
@@ -33,7 +32,7 @@ public class DrillUtilsTest {
             blank.addHole(new HoleSpec(i, 0.0, 0.0, spacing));
         }
         java.util.List<Double> drillSet = java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0);
-        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0, 100.0, HeaderType.PRESSURE);
+        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0);
 
         HoleLayout layout = DrillUtils.taperWithRules(blank, drillSet, params);
         double prev = 0.0;
@@ -52,14 +51,13 @@ public class DrillUtilsTest {
             blank.addHole(new HoleSpec(i, 0.0, 0.0, spacing));
         }
         java.util.List<Double> drillSet = java.util.List.of(16.0);
-        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0, 100.0, HeaderType.PRESSURE);
+        FlowParameters params = new FlowParameters(150.0, 6.309, 1200.0);
 
         HoleLayout layout = DrillUtils.taperWithRules(blank, drillSet, params);
         for (HoleSpec h : layout.getHoles()) {
             assertEquals(16.0, h.holeDiameterMm());
         }
-        FlowParameters tuned2 = FlowPhysics.balanceSupplyPressure(layout, params);
-        double err = FlowPhysics.computeUniformityError(layout, tuned2);
+        double err = FlowPhysics.computeUniformityError(layout, params);
         assertTrue(err > 5.0);
     }
 
@@ -75,7 +73,7 @@ public class DrillUtilsTest {
 
         double gpm = 120.0;
         double lps = gpm * 0.0631;
-        FlowParameters params = new FlowParameters(200.0, lps, 1300.0, 100.0, HeaderType.PRESSURE);
+        FlowParameters params = new FlowParameters(200.0, lps, 1300.0);
 
         HoleLayout layout = DrillUtils.taperWithRules(blank, drillSet, params);
         java.util.Set<Double> used = new java.util.HashSet<>();
@@ -83,8 +81,7 @@ public class DrillUtilsTest {
             used.add(h.holeDiameterMm());
         }
         assertTrue(used.size() >= 4, "Expected at least 4 drill sizes but got " + used.size());
-        FlowParameters tuned3 = FlowPhysics.balanceSupplyPressure(layout, params);
-        double err = FlowPhysics.computeUniformityError(layout, tuned3);
+        double err = FlowPhysics.computeUniformityError(layout, params);
         assertTrue(err <= 5.0, "Uniformity error too high: " + err);
     }
 }

--- a/src/test/java/org/example/flowmod/engine/FlowPhysicsTest.java
+++ b/src/test/java/org/example/flowmod/engine/FlowPhysicsTest.java
@@ -31,7 +31,7 @@ public class FlowPhysicsTest {
     public void testComputeReynolds() {
         double gpm = 100.0;
         double lps = gpm * 0.0631;
-        FlowParameters p = new FlowParameters(150.0, lps, 1000.0, 100.0, HeaderType.PRESSURE);
+        FlowParameters p = new FlowParameters(150.0, lps, 1000.0);
         double Re = FlowPhysics.computeReynolds(p);
         assertEquals(1.9e5, Re, 2e4);
     }

--- a/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerRuntimeTest.java
+++ b/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerRuntimeTest.java
@@ -15,17 +15,41 @@ public class RuleBasedHoleOptimizerRuntimeTest {
 
         double gpm = 120.0;
         double lps = gpm * 0.0631;
-        FlowParameters p = new FlowParameters(200.0, lps, 1300.0, 100.0, HeaderType.PRESSURE);
+        FlowParameters p = new FlowParameters(200.0, lps, 1300.0);
 
         HoleLayout layout = optimizer.optimize(p);
         assertNotNull(layout);
         assertTrue(layout.getHoles().size() > 0);
 
-        FlowParameters tuned = FlowPhysics.balanceSupplyPressure(layout, p);
-        double err = FlowPhysics.computeUniformityError(layout, tuned);
+        double err = FlowPhysics.computeUniformityError(layout, p);
         assertTrue(err <= 5.0);
         HoleSpec last = layout.getHoles().get(layout.getHoles().size() - 1);
         double spacing = p.headerLenMm() / layout.getHoles().size();
         assertEquals(p.headerLenMm(), last.axialPosMm() + spacing, spacing * 0.01);
+    }
+
+    @Test
+    public void testSuctionSolverResults() {
+        DrillSizePolicy policy = new DefaultDrillSizePolicy();
+        FlowPhysics physics = new FlowPhysics();
+        DesignRules rules = new BasicDesignRules(10, java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0));
+        RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
+
+        double gpm = 120.0;
+        double lps = gpm * 0.0631;
+        FlowParameters p = new FlowParameters(200.0, lps, 1300.0);
+
+        HoleLayout layout = optimizer.optimize(p);
+        java.util.Set<Double> used = new java.util.HashSet<>();
+        for (HoleSpec h : layout.getHoles()) {
+            used.add(h.holeDiameterMm());
+        }
+        assertTrue(used.size() >= 3, "Expected at least 3 drill sizes");
+
+        double err = FlowPhysics.computeUniformityError(layout, p);
+        assertTrue(err <= 5.0, "Uniformity too high: " + err);
+
+        double suction = FlowPhysics.findRequiredSuctionKPa(layout, p, -100.0, -1.0);
+        assertTrue(suction <= -1.0 && suction >= -100.0, "suction " + suction);
     }
 }

--- a/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/engine/RuleBasedHoleOptimizerTest.java
@@ -17,14 +17,13 @@ public class RuleBasedHoleOptimizerTest {
         DesignRules rules = new BasicDesignRules(10,
                 java.util.List.of(16.0, 14.0, 12.0, 10.0, 8.0, 6.0, 4.0));
         RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
-        FlowParameters p1 = new FlowParameters(150.0, 6.309, 1200.0, 100.0, HeaderType.PRESSURE);
+        FlowParameters p1 = new FlowParameters(150.0, 6.309, 1200.0);
         HoleLayout layout = optimizer.optimize(p1);
         assertNotNull(layout);
         assertNotNull(layout.getHoles());
         int expectedRows1 = (int) Math.floor(p1.headerLenMm() / DesignRules.DEFAULT_ROW_SPACING_MM);
         assertEquals(expectedRows1, layout.getHoles().size());
-        FlowParameters tuned1 = FlowPhysics.balanceSupplyPressure(layout, p1);
-        double err1 = FlowPhysics.computeUniformityError(layout, tuned1);
+        double err1 = FlowPhysics.computeUniformityError(layout, p1);
         assertTrue(err1 <= 5.0);
         for (HoleSpec h : layout.getHoles()) {
             assertTrue(rules.allowableDrillSizesMm().contains(h.holeDiameterMm()));
@@ -33,12 +32,11 @@ public class RuleBasedHoleOptimizerTest {
         double spacing1 = p1.headerLenMm() / layout.getHoles().size();
         assertEquals(p1.headerLenMm(), last1.axialPosMm() + spacing1, spacing1 * 0.01);
 
-        FlowParameters p2 = new FlowParameters(400.0, 31.5, 2000.0, 100.0, HeaderType.PRESSURE);
+        FlowParameters p2 = new FlowParameters(400.0, 31.5, 2000.0);
         HoleLayout layout2 = optimizer.optimize(p2);
         int expectedRows2 = (int) Math.floor(p2.headerLenMm() / DesignRules.DEFAULT_ROW_SPACING_MM);
         assertEquals(expectedRows2, layout2.getHoles().size());
-        FlowParameters tuned2 = FlowPhysics.balanceSupplyPressure(layout2, p2);
-        double err2 = FlowPhysics.computeUniformityError(layout2, tuned2);
+        double err2 = FlowPhysics.computeUniformityError(layout2, p2);
         assertTrue(err2 <= 5.0);
         HoleSpec last2 = layout2.getHoles().get(layout2.getHoles().size() - 1);
         double spacing2 = p2.headerLenMm() / layout2.getHoles().size();
@@ -52,7 +50,7 @@ public class RuleBasedHoleOptimizerTest {
         DesignRules rules = new DesignRules() {};
         RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
 
-        FlowParameters p = new FlowParameters(200.0, 10.0, 1500.0, 100.0, HeaderType.PRESSURE);
+        FlowParameters p = new FlowParameters(200.0, 10.0, 1500.0);
         HoleLayout layout = optimizer.optimize(p);
         assertNotNull(layout);
         int expectedRows = (int) Math.floor(p.headerLenMm() / DesignRules.DEFAULT_ROW_SPACING_MM);
@@ -68,10 +66,9 @@ public class RuleBasedHoleOptimizerTest {
         RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
 
         double lps = 120.0 * 0.0631;
-        FlowParameters p = new FlowParameters(200.0, lps, 1300.0, 100.0, HeaderType.PRESSURE);
+        FlowParameters p = new FlowParameters(200.0, lps, 1300.0);
         HoleLayout layout = optimizer.optimize(p);
-        FlowParameters tuned = FlowPhysics.balanceSupplyPressure(layout, p);
-        double err = FlowPhysics.computeUniformityError(layout, tuned);
+        double err = FlowPhysics.computeUniformityError(layout, p);
         assertTrue(err <= 5.0, "Uniformity too high: " + err);
     }
 
@@ -84,7 +81,7 @@ public class RuleBasedHoleOptimizerTest {
         RuleBasedHoleOptimizer optimizer = new RuleBasedHoleOptimizer(rules, policy, physics);
 
         double lps = 1000.0 * 0.0631;
-        FlowParameters p = new FlowParameters(50.0, lps, 100.0, 100.0, HeaderType.PRESSURE);
+        FlowParameters p = new FlowParameters(50.0, lps, 100.0);
 
         java.time.Duration timeout = java.time.Duration.ofSeconds(5);
         org.junit.jupiter.api.Assertions.assertTimeoutPreemptively(timeout, () ->


### PR DESCRIPTION
## Summary
- drop supply pressure input from `FlowParameters`
- compute suction pressure using new `findRequiredSuctionKPa`
- adjust tapering algorithm to use suction solver
- update main UI & controller to remove pressure field
- revise tests and add suction solver test

## Testing
- `./gradlew test` *(fails: No route to host)*