### PR TITLE
Fix suction solver bracketing and tests

### DIFF
--- a/src/main/java/org/example/flowmod/app/MainController.java
+++ b/src/main/java/org/example/flowmod/app/MainController.java
@@ -91,7 +91,7 @@ public final class MainController {
             sheetLabel.setText(String.format("Sheet: %.0f mm × %.0f mm",
                     circumference, p.headerLenMm()));
         } catch (DesignNotConvergedException ex) {
-            statusLabel.setText("❌ " + ex.getMessage());
+            showError(ex.getMessage());
             table.getItems().clear();
 
         } catch (Throwable t) {

--- a/src/main/java/org/example/flowmod/engine/FlowPhysics.java
+++ b/src/main/java/org/example/flowmod/engine/FlowPhysics.java
@@ -86,7 +86,7 @@ public final class FlowPhysics {
 
         for (int i = 0; i < rows; i++) {
             HoleSpec h = holes.get(i);
-            double dp = Math.abs(localP);
+            double dp = -localP;
             qh[i] = orificeFlowLps(h.holeDiameterMm(), dp);
 
             pipeFlow -= qh[i];
@@ -111,7 +111,15 @@ public final class FlowPhysics {
             double total = flows.stream().mapToDouble(Double::doubleValue).sum();
             return total - p.flowLps();
         };
-        double root = solver.solve(100, fn, pMin, pMax);
+
+        double low = -200.0;
+        double high = -0.5;
+        double fHigh = fn.value(high);
+        if (fHigh < 0) {
+            throw new DesignNotConvergedException("Suction exceeds -0.5 kPa");
+        }
+
+        double root = solver.solve(100, fn, low, high);
         for (int i = 0; i < 20; i++) {
             double err = fn.value(root);
             if (Math.abs(err) < 1e-4) {

--- a/src/test/java/org/example/flowmod/engine/FlowPhysicsTest.java
+++ b/src/test/java/org/example/flowmod/engine/FlowPhysicsTest.java
@@ -35,4 +35,11 @@ public class FlowPhysicsTest {
         double Re = FlowPhysics.computeReynolds(p);
         assertEquals(1.9e5, Re, 2e4);
     }
+
+    @Test
+    public void testOrificeMonotonic() {
+        double q1 = FlowPhysics.orificeFlowLps(40.0, 1.0);
+        double q100 = FlowPhysics.orificeFlowLps(40.0, 100.0);
+        assertTrue(q1 * 10 <= q100);
+    }
 }


### PR DESCRIPTION
## Summary
- correct pressure sign in `rowFlows`
- limit suction search range in `findRequiredSuctionKPa`
- display convergence error message in MainController
- add unit test validating orifice flow monotonicity

## Testing
- `./gradlew test` *(fails: No route to host)*